### PR TITLE
Add GitHub Actions PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish Python package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Build and publish package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,4 @@ script:
 #after_success:
   #codecov
 
-deploy:
-  provider: pypi
-  user: $PYPI_USER
-  password: $PYPI_PASS
-  server: https://upload.pypi.org/legacy/
-  distributions: "sdist bdist_wheel"
-  on:
-    branch: master
-    condition: $TRAVIS_PYTHON_VERSION = "3.8"
+# PyPI publishing is handled by .github/workflows/publish.yml.


### PR DESCRIPTION
After merging, configure a PyPI trusted publisher for Freely-Given-org/BibleOrgSys and publish a v0.3.6 GitHub Release to upload the updated package. The workflow replaces the obsolete Travis PyPI deployment.